### PR TITLE
feat docker via scheme

### DIFF
--- a/documentation/src/utils/install-links.ts
+++ b/documentation/src/utils/install-links.ts
@@ -29,7 +29,7 @@ export function getGooseInstallLink(server: MCPServer): string {
   }
   
   const parts = server.command.split(" ");
-  const baseCmd = parts[0]; // jbang, npx or uvx
+  const baseCmd = parts[0]; // docker, jbang, npx or uvx
   const args = parts.slice(1); // remaining arguments
 
   const queryParams = [

--- a/ui/desktop/src/components/settings_v2/extensions/deeplink.ts
+++ b/ui/desktop/src/components/settings_v2/extensions/deeplink.ts
@@ -15,7 +15,7 @@ function getStdioConfig(
   timeout: number
 ) {
   // Validate that the command is one of the allowed commands
-  const allowedCommands = ['jbang', 'npx', 'uvx', 'goosed'];
+  const allowedCommands = ['docker', 'jbang', 'npx', 'uvx', 'goosed'];
   if (!allowedCommands.includes(cmd)) {
     toastService.handleError(
       'Invalid Command',

--- a/ui/desktop/src/components/settings_v2/extensions/utils.ts
+++ b/ui/desktop/src/components/settings_v2/extensions/utils.ts
@@ -168,7 +168,7 @@ export async function replaceWithShims(cmd: string) {
 
 export function removeShims(cmd: string) {
   // Only remove shims if the path matches our known shim patterns
-  const shimPatterns = [/goosed$/, /jbang$/, /npx$/, /uvx$/];
+  const shimPatterns = [/goosed$/, /docker$/, /jbang$/, /npx$/, /uvx$/];
 
   // Check if the command matches any shim pattern
   const isShim = shimPatterns.some((pattern) => pattern.test(cmd));

--- a/ui/desktop/src/extensions.tsx
+++ b/ui/desktop/src/extensions.tsx
@@ -362,7 +362,7 @@ function getStdioConfig(
   description: string,
   parsedTimeout: number
 ) {
-  const allowedCommands = ['jbang', 'npx', 'uvx', 'goosed'];
+  const allowedCommands = ['docker', 'jbang', 'npx', 'uvx', 'goosed'];
   if (!allowedCommands.includes(cmd)) {
     handleError(
       `Failed to install extension: Invalid command: ${cmd}. Only ${allowedCommands.join(', ')} are allowed.`,


### PR DESCRIPTION
Adds `docker` to the list of allowed commands to install via deeplinks.

Given that upx / npx can run arbitrary code from a repository, this doesn't seem to be a change in the security threat model.

There is also a "good" argument that docker could be a first-class command type rather than just another command invoked by a shell - but that won't be addressed here.